### PR TITLE
Add CODEOWNERS file to specify repository owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @repository-owners


### PR DESCRIPTION
This file designates `@repository-owners` as code owners for all files. It automates ownership assignment for reviews and ensures clear responsibility.